### PR TITLE
feat(global): make modules global

### DIFF
--- a/build/helpers/args-list.js
+++ b/build/helpers/args-list.js
@@ -9,9 +9,9 @@ var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol
 exports.getArgsList = getArgsList;
 exports.getMethod = getMethod;
 
-var _argsList = require('args-list');
+var _functionArguments = require('function-arguments');
 
-var _argsList2 = _interopRequireDefault(_argsList);
+var _functionArguments2 = _interopRequireDefault(_functionArguments);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -20,7 +20,7 @@ function getArgsList(target) {
     return target.slice(0, target.length - 1);
   }
   if (typeof target === 'function') {
-    return (0, _argsList2.default)(target);
+    return (0, _functionArguments2.default)(target);
   }
 }
 

--- a/build/helpers/bootstrap.js
+++ b/build/helpers/bootstrap.js
@@ -4,8 +4,13 @@ var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol
 
 var _argsList = require('./args-list');
 
-function bootstrap(module) {
+var _module = require('../module/module');
+
+function bootstrap(moduleOrName) {
+  var module = (typeof moduleOrName === 'undefined' ? 'undefined' : _typeof(moduleOrName)) === 'object' ? moduleOrName : _module.modules[moduleOrName];
+
   module.dependencies.map(bootstrap);
+
   if (module.runnableMethod) {
 
     var runnableMethod = undefined;

--- a/build/index.js
+++ b/build/index.js
@@ -1,7 +1,17 @@
 'use strict';
 
-var jedi = {};
-jedi.module = require('./module/module');
-jedi.bootstrap = require('./helpers/bootstrap');
+var _module = require('./module/module');
 
-module.exports = jedi;
+var _module2 = _interopRequireDefault(_module);
+
+var _bootstrap = require('./helpers/bootstrap');
+
+var _bootstrap2 = _interopRequireDefault(_bootstrap);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+module.exports = {
+  module: _module2.default,
+  modules: _module.modules,
+  bootstrap: _bootstrap2.default
+};

--- a/build/module/get.js
+++ b/build/module/get.js
@@ -7,6 +7,8 @@ exports.default = resolveName;
 
 var _argsList = require('../helpers/args-list');
 
+var _module = require('./module');
+
 function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } else { return Array.from(arr); } }
 
 function resolveName(name) {
@@ -30,9 +32,9 @@ function resolveName(name) {
   }
 
   if (this.dependencies[0]) {
-    var _result2 = this.dependencies.reduce(function (injectable, depModule) {
+    var _result2 = this.dependencies.reduce(function (injectable, depModuleName) {
       try {
-        return injectable || depModule.get(name);
+        return injectable || _module.modules[depModuleName].get(name);
       } catch (err) {
         return injectable;
       }

--- a/build/module/module.js
+++ b/build/module/module.js
@@ -1,5 +1,11 @@
 'use strict';
 
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.modules = undefined;
+exports.default = createModule;
+
 var _resolve = require('./resolve');
 
 var _resolve2 = _interopRequireDefault(_resolve);
@@ -26,10 +32,15 @@ var _run2 = _interopRequireDefault(_run);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-module.exports = function createModule(dependencies) {
+var modules = exports.modules = {};
+
+function createModule(name, dependencies) {
   var module = {};
 
-  module.dependencies = dependencies || [];
+  module.name = name;
+  module.dependencies = dependencies && dependencies.map(function (d) {
+    return typeof d === 'string' ? d : d.name;
+  }) || [];
 
   module.injectables = {};
   module.factories = {};
@@ -45,5 +56,7 @@ module.exports = function createModule(dependencies) {
   module.resolve = _resolve2.default.bind(module);
   module.get = _get2.default.bind(module);
 
+  modules[name] = module;
+
   return module;
-};
+}

--- a/build/module/run.js
+++ b/build/module/run.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var _argsList = require('args-list');
+var _functionArguments = require('function-arguments');
 
-var _argsList2 = _interopRequireDefault(_argsList);
+var _functionArguments2 = _interopRequireDefault(_functionArguments);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "sinon-chai": "^2.8.0"
   },
   "dependencies": {
-    "args-list": "^0.3.3"
+    "args-list": "^0.3.3",
+    "function-arguments": "^1.0.4"
   }
 }

--- a/src/helpers/args-list.js
+++ b/src/helpers/args-list.js
@@ -1,4 +1,4 @@
-import argsList from 'args-list';
+import argsList from 'function-arguments';
 
 export function getArgsList(target) {
   if (typeof target === 'object' && target.length && typeof target[target.length - 1] === 'function') {

--- a/src/helpers/bootstrap.js
+++ b/src/helpers/bootstrap.js
@@ -1,7 +1,11 @@
 import {getArgsList} from './args-list';
+import {modules} from '../module/module';
 
-function bootstrap(module) {
+function bootstrap(moduleOrName) {
+  const module = typeof moduleOrName === 'object' ? moduleOrName : modules[moduleOrName];
+
   module.dependencies.map(bootstrap);
+
   if (module.runnableMethod) {
 
     let runnableMethod;

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,10 @@
 'use strict';
 
-const jedi = {};
-jedi.module = require('./module/module');
-jedi.bootstrap = require('./helpers/bootstrap');
+import moduleCreator, {modules} from './module/module';
+import bootstrap from './helpers/bootstrap';
 
-module.exports = jedi;
+module.exports = {
+  module: moduleCreator,
+  modules,
+  bootstrap
+};

--- a/src/module/get.js
+++ b/src/module/get.js
@@ -1,4 +1,5 @@
 import {getArgsList, getMethod} from '../helpers/args-list';
+import {modules} from './module';
 
 export default function resolveName(name) {
   const fromInjectable = this.injectables[name]
@@ -21,9 +22,9 @@ export default function resolveName(name) {
   }
 
   if (this.dependencies[0]) {
-    const result = this.dependencies.reduce(function (injectable, depModule) {
+    const result = this.dependencies.reduce(function (injectable, depModuleName) {
       try {
-        return injectable || depModule.get(name);
+        return injectable || modules[depModuleName].get(name);
       } catch (err) {
         return injectable;
       }

--- a/src/module/module.js
+++ b/src/module/module.js
@@ -5,10 +5,13 @@ import factory from './factory';
 import service from './service';
 import run from './run';
 
-module.exports = function createModule(dependencies) {
+export const modules = {};
+
+export default function createModule(name, dependencies) {
   const module = {};
 
-  module.dependencies = dependencies || [];
+  module.name = name;
+  module.dependencies = dependencies && dependencies.map(d => typeof d === 'string' ? d : d.name) || [];
 
   module.injectables = {};
   module.factories = {};
@@ -23,6 +26,8 @@ module.exports = function createModule(dependencies) {
 
   module.resolve = resolve.bind(module);
   module.get = get.bind(module);
+
+  modules[name] = module;
 
   return module;
 }

--- a/src/module/run.js
+++ b/src/module/run.js
@@ -1,4 +1,4 @@
-import argsList from 'args-list';
+import argsList from 'function-arguments';
 
 module.exports = function run(fn) {
   this.runnableMethod = fn;

--- a/tests/bootstrap/bootstrap.spec.js
+++ b/tests/bootstrap/bootstrap.spec.js
@@ -9,7 +9,7 @@ import jedi from '../../src';
 describe('Module bootstraping', function () {
   let jediModule;
   beforeEach(function () {
-    jediModule = jedi.module();
+    jediModule = jedi.module('somemodule', []);
   });
 
   describe('jedi.bootstrap() method', function () {
@@ -19,6 +19,17 @@ describe('Module bootstraping', function () {
 
       // When
       jedi.bootstrap(jediModule);
+
+      // Then
+      expect(jediModule.runnableMethod.called).to.be.true;
+    });
+
+    it('should accept a module string name as argument', function () {
+      // Given
+      jediModule.runnableMethod = stub();
+
+      // When
+      jedi.bootstrap('somemodule');
 
       // Then
       expect(jediModule.runnableMethod.called).to.be.true;
@@ -67,13 +78,13 @@ describe('Module bootstraping', function () {
     it('should run a module\'s dependencies\' runnables in ordre before its own runnable', function () {
       // Given
       const runnable1 = stub();
-      const module1 = jedi.module().run(runnable1);
+      const module1 = jedi.module('module1', []).run(runnable1);
 
       const runnable2 = stub();
-      const module2 = jedi.module().run(runnable2);
+      const module2 = jedi.module('module2', []).run(runnable2);
 
       const finalRunnable = stub();
-      const finalModule = jedi.module([module1, module2]).run(finalRunnable);
+      const finalModule = jedi.module('module3', [module1, module2]).run(finalRunnable);
 
       // When
       jedi.bootstrap(finalModule);

--- a/tests/module/dependencies.spec.js
+++ b/tests/module/dependencies.spec.js
@@ -7,18 +7,18 @@ describe('Module dependencies', function () {
   describe('a module .module() method', function () {
     it('can register an array of dependencies if given', function () {
       // Given
-      const module1 = jedi.module();
+      const module1 = jedi.module('module1', []);
 
       // When
-      const module2 = jedi.module([module1]);
+      const module2 = jedi.module('module2', [module1]);
 
       // Then
-      expect(module2.dependencies).to.include(module1);
+      expect(module2.dependencies).to.include(module1.name);
     });
 
     it('should set its dependencies to an empty array if none are given', function () {
       // When
-      const module1 = jedi.module();;
+      const module1 = jedi.module('module1', []);;
 
       // Then
       expect(module1.dependencies).to.deep.equal([]);
@@ -29,7 +29,7 @@ describe('Module dependencies', function () {
     it('should look up injectables in dependencies if not found in the module', function () {
       // Given
       const module1 = jedi
-        .module()
+        .module('module1', [])
         .register('foo', 'bar')
         .factory('baz', function (foo) {
           return `${foo}qux`;
@@ -39,7 +39,7 @@ describe('Module dependencies', function () {
         });
 
       const module2 = jedi
-        .module([module1]);
+        .module('module2', [module1]);
 
       // When
       const result = module2.resolve(['quz']);
@@ -51,11 +51,11 @@ describe('Module dependencies', function () {
     });
 
     it('should add injectables resolved from a dependency to the module\'s own injectables', function () {
-      const module1 = jedi.module();
+      const module1 = jedi.module('module1', []);
 
       module1.get = stub().withArgs('foo').returns('bar');
 
-      const module2 = jedi.module([module1]);
+      const module2 = jedi.module('module2', [module1]);
 
       module2.resolve(['foo']);
 

--- a/tests/module/injection-resolver.spec.js
+++ b/tests/module/injection-resolver.spec.js
@@ -8,7 +8,7 @@ describe('Injection resolver', function () {
     it('should return an array of injected injectables given their names', function () {
       // Given
       const jediModule = jedi
-        .module()
+        .module('jediModule', [])
         .register('foo', 'bar')
         .factory('baz', function (foo) {
           return `${foo}qux`;
@@ -29,7 +29,7 @@ describe('Injection resolver', function () {
     it('should be able to support ng-annotate style injections', function () {
       // Given
       const jediModule = jedi
-        .module()
+        .module('jediModule', [])
         .register('foo', 'bar')
         .factory('baz', ['foo', function (foo) {
           return `${foo}qux`;
@@ -48,7 +48,7 @@ describe('Injection resolver', function () {
     });
 
     it('should throw an error when the module is not found', function () {
-      const jediModule = jedi.module();
+      const jediModule = jedi.module('jediModule', []);
 
       // When
       function thrower() {

--- a/tests/module/register-methods.spec.js
+++ b/tests/module/register-methods.spec.js
@@ -5,7 +5,7 @@ import jedi from '../../src';
 describe('Injectable registration', function () {
   let module;
   beforeEach(function () {
-    module = jedi.module();
+    module = jedi.module('module1', []);
   });
 
   const testErrorsForRegistered = (method) => {


### PR DESCRIPTION
This commit adds a `modules` variable in jedi, holding a map from module
names to modules.

This is also breaking changes as you now need to do the following to
register a module:

```
const moduleB = jedi.module('module-b', [])
  .service('hello', function () {
    this.sayHello = () => console.log('hello');
  });

const moduleName = jedi
  .module('module-name', ['b'])
  .run((hello) => hello.sayHello())
  .name;

jedi.bootstrap('module-name');
// Prints 'hello' to console
```