### PR TITLE
fix(boostrap): prevent multiple .run calls

### DIFF
--- a/build/helpers/bootstrap.js
+++ b/build/helpers/bootstrap.js
@@ -20,7 +20,7 @@ function bootstrap(moduleOrName) {
     module.services = Object.assign(module.services, _module.modules[dependency].services);
   });
 
-  if (module.runnableMethod) {
+  if (module.runnableMethod && !module.runnableMethodRan) {
     var runnableMethod = undefined;
     var args = undefined;
 
@@ -35,6 +35,7 @@ function bootstrap(moduleOrName) {
     }
 
     runnableMethod.apply(module, module.resolve(args));
+    module.runnableMethodRan = true;
   }
 };
 

--- a/src/helpers/bootstrap.js
+++ b/src/helpers/bootstrap.js
@@ -15,7 +15,7 @@ function bootstrap(moduleOrName) {
     module.services = Object.assign(module.services, modules[dependency].services);
   });
 
-  if (module.runnableMethod) {
+  if (module.runnableMethod && !module.runnableMethodRan) {
     let runnableMethod;
     let args;
 
@@ -30,6 +30,7 @@ function bootstrap(moduleOrName) {
     }
 
     runnableMethod.apply(module, module.resolve(args));
+    module.runnableMethodRan = true;
   }
 };
 

--- a/tests/bootstrap/bootstrap.spec.js
+++ b/tests/bootstrap/bootstrap.spec.js
@@ -102,5 +102,22 @@ describe('Module bootstraping', function () {
       // Then
       expect(jedi.bootstrap.bind(null, module)).to.throw('Module not found someinexistant-module')
     });
+
+    it('should run a module\'s runnable method only once on bootstrap', function () {
+      // Given
+      const runnable1 = stub();
+      const module1 = jedi.module('module1', []).run(runnable1);
+
+      const module2 = jedi.module('module2', ['module1']);
+      const module3 = jedi.module('module3', ['module1']);
+
+      const module4 = jedi.module('module4', ['module2', 'module3']);
+
+      // When
+      jedi.bootstrap(module4);
+
+      // Then
+      expect(runnable1.callCount).to.equal(1);
+    });
   });
 });


### PR DESCRIPTION
This commit prevents runnable methods from being called several times
when a module is a dependency of multiple modules.