### PR TITLE
feat(resolve): make injectables global

### DIFF
--- a/build/module/get.js
+++ b/build/module/get.js
@@ -11,13 +11,20 @@ var _module = require('./module');
 
 function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } else { return Array.from(arr); } }
 
+var injectables = {};
+
 function resolveName(name) {
   var _this = this;
 
   try {
-    var fromInjectable = this.injectables[name];
-    if (fromInjectable) {
-      return fromInjectable;
+    var fromGlobalInjectable = injectables[name];
+    if (fromGlobalInjectable) {
+      return fromGlobalInjectable;
+    }
+
+    var fromModuleInjectable = this.injectables[name];
+    if (fromModuleInjectable) {
+      return fromModuleInjectable;
     }
 
     var fromFactory = this.factories[name];
@@ -25,7 +32,7 @@ function resolveName(name) {
       var result = (0, _argsList.getMethod)(fromFactory).apply(undefined, _toConsumableArray((0, _argsList.getArgsList)(fromFactory).map(function (arg) {
         return _this.get(arg);
       })));
-      this.injectables[name] = result;
+      injectables[name] = result;
       return result;
     }
 
@@ -34,7 +41,7 @@ function resolveName(name) {
       var _result = new (Function.prototype.bind.apply((0, _argsList.getMethod)(fromServices), [null].concat(_toConsumableArray((0, _argsList.getArgsList)(fromServices).map(function (arg) {
         return _this.get(arg);
       })))))();
-      this.injectables[name] = _result;
+      injectables[name] = _result;
       return _result;
     }
 
@@ -46,9 +53,10 @@ function resolveName(name) {
           return injectable;
         }
       }, null);
-      this.injectables[name] = _result2;
+      injectables[name] = _result2;
       return _result2;
     }
+
     throw new Error('Impossible to find module \'' + name + '\'');
   } catch (err) {
     throw err;

--- a/src/module/get.js
+++ b/src/module/get.js
@@ -1,24 +1,31 @@
 import {getArgsList, getMethod} from '../helpers/args-list';
 import {modules} from './module';
 
+const injectables = {};
+
 export default function resolveName(name) {
   try {
-    const fromInjectable = this.injectables[name]
-    if (fromInjectable) {
-      return fromInjectable;
+    const fromGlobalInjectable = injectables[name];
+    if (fromGlobalInjectable) {
+      return fromGlobalInjectable;
+    }
+
+    const fromModuleInjectable = this.injectables[name];
+    if (fromModuleInjectable) {
+      return fromModuleInjectable;
     }
 
     const fromFactory = this.factories[name];
     if (fromFactory) {
       const result = getMethod(fromFactory)(...getArgsList(fromFactory).map(arg => this.get(arg)));
-      this.injectables[name] = result;
+      injectables[name] = result;
       return result;
     }
 
     const fromServices = this.services[name];
     if (fromServices) {
       const result = new (getMethod(fromServices))(...getArgsList(fromServices).map(arg => this.get(arg)));
-      this.injectables[name] = result;
+      injectables[name] = result;
       return result;
     }
 
@@ -30,11 +37,11 @@ export default function resolveName(name) {
           return injectable;
         }
       }, null);
-      this.injectables[name] = result;
+      injectables[name] = result;
       return result;
     }
-    throw new Error(`Impossible to find module '${name}'`);
 
+    throw new Error(`Impossible to find module '${name}'`);
   } catch (err) {
     throw err;
   }

--- a/tests/module/dependencies.spec.js
+++ b/tests/module/dependencies.spec.js
@@ -3,7 +3,6 @@ import {stub} from 'sinon';
 import jedi from '../../src';
 
 describe('Module dependencies', function () {
-
   describe('a module .module() method', function () {
     it('can register an array of dependencies if given', function () {
       // Given
@@ -48,19 +47,6 @@ describe('Module dependencies', function () {
       expect(result).to.deep.equal([{
         bla: 'barquxblu'
       }]);
-    });
-
-    it('should add injectables resolved from a dependency to the module\'s own injectables', function () {
-      const module1 = jedi.module('module1', []);
-
-      module1.get = stub().withArgs('foo').returns('bar');
-
-      const module2 = jedi.module('module2', [module1]);
-
-      module2.resolve(['foo']);
-
-      // Then
-      expect(module2.injectables.foo).to.equal('bar')
     });
   });
 });


### PR DESCRIPTION
This commit stores injectables globally to prevent multiple versions of
injectables from coexisting in an application.

Note: this will cause problems in the future, and we will have to handle
jedi module usage differently in v2.0.0